### PR TITLE
fix: remove required headless

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
     sha256: 88931673fa9ba5b9f416456d39ca02dff7a1180b52a7ae981e4a4cbdb6bf19b2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -33,7 +33,7 @@ requirements:
     - lxml >=4.2.5
     - nltk >=3.9.1
     - numpy >=1.26.4,<3.0.0
-    - py-opencv >=4.12.0 headless*
+    - py-opencv >=4.12.0
     - pandas >=0.24.0
     - pydantic >=1.9.2
     - pydantic-core >=2.18.2


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Remove headless for opencv. It's not required, and hinders installation of non-headless versions in depending packages. 

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed) not needed
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
